### PR TITLE
0.4 restructuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "askama"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,10 +190,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "cc"
+version = "1.2.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -193,10 +218,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "fnv"
@@ -250,6 +300,18 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -363,6 +425,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +474,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -467,7 +563,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -547,6 +643,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,6 +667,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -673,6 +813,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +834,8 @@ dependencies = [
  "askama",
  "askama_axum",
  "axum",
+ "chrono",
+ "rand",
  "serde",
  "tokio",
  "toml",
@@ -909,6 +1057,142 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb307e42a74fb6de9bf3a02d9712678b22399c87e6fa869d6dfcd8c1b7754e0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0abd1ddbc6964ac14db11c7213d6532ef34bd9aa042c2e5935f59d7908b46a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,3 +1270,29 @@ name = "winnow"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2024"
 askama = { version = "0.12", features = ["with-axum"] }
 askama_axum = "0.4"
 axum = "0.7"
+chrono = "0.4.42"
+rand = "0.9.2"
 serde = { version = "1.0.228", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 toml = "0.9.7"

--- a/data/zones.toml
+++ b/data/zones.toml
@@ -1,3 +1,5 @@
+labels = ["name", "size", "acte", "bosses", "station"]
+
 [[zones]]
 name = "Moss Grotto"
 size = 18

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -1,0 +1,60 @@
+use std::fmt;
+
+use crate::models::Zone;
+
+#[derive(Debug, Clone)]
+pub enum CompareResult {
+    Smaller,
+    Greater,
+    Equal,
+    NotCorrect,
+}
+
+impl fmt::Display for CompareResult {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CompareResult::Smaller => write!(f, "Smaller"),
+            CompareResult::Greater => write!(f, "Greater"),
+            CompareResult::Equal => write!(f, "Equal"),
+            CompareResult::NotCorrect => write!(f, "NotCorrect"),
+        }
+    }
+}
+
+pub fn compare_values<T: Ord>(a: &T, b: &T) -> CompareResult {
+    if a < b {
+        CompareResult::Smaller
+    } else if a > b {
+        CompareResult::Greater
+    } else {
+        CompareResult::Equal
+    }
+}
+
+pub fn compare_str(a: &str, b: &str) -> CompareResult {
+    if a == b {
+        CompareResult::Equal
+    } else {
+        CompareResult::NotCorrect
+    }
+}
+
+pub fn compare_bool(a: &bool, b: &bool) -> CompareResult {
+    if a == b {
+        CompareResult::Equal
+    } else {
+        CompareResult::NotCorrect
+    }
+}
+
+impl Zone {
+    pub fn compare(&self, other: &Zone) -> Vec<CompareResult> {
+        vec![
+            compare_str(&self.name, &other.name),
+            compare_values(&self.size, &other.size),
+            compare_values(&self.acte, &other.acte),
+            compare_values(&self.bosses, &other.bosses),
+            compare_bool(&self.station, &other.station),
+        ]
+    }
+}

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,0 +1,57 @@
+use std::sync::Arc;
+
+use axum::{extract::{Form, State}, response::IntoResponse};
+use serde::Deserialize;
+
+use crate::{
+    state::AppState,
+    templates::HomepageTemplate,
+    utils::{load_labels_and_zones, label_results, load_zones},
+    models::Zone,
+};
+
+pub async fn homepage() -> impl IntoResponse {
+    HomepageTemplate {
+        results_history: vec![],
+        zones: load_zones(),
+    }
+}
+
+#[derive(Deserialize)]
+pub struct ZoneChoice {
+    pub zone_name: String,
+}
+
+pub async fn choose_zone(
+    State(state): State<Arc<AppState>>,
+    Form(input): Form<ZoneChoice>
+) -> impl IntoResponse {
+    // target hardcoded for now (need to be chosen every day randomly)
+    let target = Zone { 
+        name: "Moss Grotto".to_string(), 
+        size: 18, 
+        acte: 1, 
+        bosses: 4, 
+        station: true 
+    };
+
+    let (labels, all_zones) = load_labels_and_zones();
+    let chosen = all_zones.iter()
+        .find(|z| z.name == input.zone_name)
+        .expect("the chosen zone does not exist");
+
+    let results = chosen.compare(&target);
+
+    let results_history = {
+        let mut guesses = state.guesses.lock().unwrap();
+        guesses.push(results);
+        guesses.iter()
+            .map(|g| label_results(g.clone(), &labels))
+            .collect()
+    };
+
+    HomepageTemplate {
+        results_history,
+        zones: all_zones,
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use serde::Deserialize;
 #[derive(Template)]
 #[template(path = "homepage.html")]
 struct HomepageTemplate {
-    results_history: Vec<Vec<(&'static str, CompareResult)>>,
+    results_history: Vec<Vec<(String, CompareResult)>>,
     zones: Vec<Zone>,
 }
 
@@ -37,32 +37,62 @@ struct ZoneChoice {
     zone_name: String,
 }
 
-fn label_results(results: Vec<CompareResult>, labels: [&'static str; 5]) -> Vec<(&'static str, CompareResult)> {
-    labels.into_iter().zip(results).collect()
+// load zones like a generic tree
+fn load_raw() -> toml::Value {
+    let zones = std::fs::read_to_string("data/zones.toml").unwrap();
+    toml::from_str(&zones).unwrap()
+}
+
+// load zones as a vector of every zones
+fn load_zones() -> Vec<Zone> {
+    let toml_str = fs::read_to_string("data/zones.toml")
+        .expect("failed to read zones.toml");
+
+    let zones_file: ZonesFile = toml::from_str(&toml_str)
+        .expect("failed to parse toml");
+
+    zones_file.zones
+}
+
+fn load_labels_and_zones() -> (Vec<String>, Vec<Zone>) {
+    let raw = load_raw();
+
+    // récupérer l'ordre des labels
+    let labels = raw["labels"]
+        .as_array().unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect::<Vec<_>>();
+
+    let zones_vec = load_zones();
+
+    (labels, zones_vec)
+}
+
+fn label_results(results: Vec<CompareResult>, labels: &Vec<String>) -> Vec<(String, CompareResult)> {
+    labels.iter().cloned().zip(results).collect()
 }
 
 async fn choose_zone(State(state): State<Arc<AppState>>, Form(input): Form<ZoneChoice>) -> impl axum::response::IntoResponse {
-    // every zones
-    let all_zones = load_zones();
-    // labels of the results
-    let labels: [&'static str; 5] = ["name", "size", "acte", "bosses", "station"];
-
-    // target zone (hardcoded for now, will change)
+    // target hardcoded for now (need to be chosen every day randomly)
     let target = Zone { name: "Moss Grotto".to_string(), size: 18, acte: 1, bosses: 4, station: true };
-    // zone name selected by the user submit in form
-    let chosen_name = input.zone_name;
-    // finding the zone struct with the name
-    let chosen = all_zones.iter().find(|z| z.name == chosen_name).expect("the chosen zone does not exist");
+    
+    // loading every labels and zones from the zones.toml file
+    let (labels, all_zones) = load_labels_and_zones();
+    // getting the zone struct with input zone name
+    let chosen = all_zones.iter()
+        .find(|z| z.name == input.zone_name)
+        .expect("the chosen zone does not exist");
 
-    // final comparison between the target and chosen zone creating a CompareResult vec, using it for display
-    let results: Vec<CompareResult> = chosen.compare(&target);
+    // actual comparison (core logic)
+    let results = chosen.compare(&target);
 
-    let results_history: Vec<Vec<(&'static str, CompareResult)>> = {
-        let mut guesses = state.guesses.lock().unwrap();
-        guesses.push(results);
-        guesses.iter()
-            .map(|g| label_results(g.clone(), labels))
-            .collect()
+    let results_history: Vec<Vec<(String, CompareResult)>> = {
+    let mut guesses = state.guesses.lock().unwrap();
+    guesses.push(results);
+    guesses.iter()
+        .map(|g| label_results(g.clone(), &labels))
+        .collect()
     };
 
     HomepageTemplate {
@@ -70,7 +100,6 @@ async fn choose_zone(State(state): State<Arc<AppState>>, Form(input): Form<ZoneC
         zones: all_zones,
     }
 }
-
 
 // core logic
 #[derive(Debug, Deserialize)]
@@ -85,16 +114,6 @@ struct Zone {
 #[derive(Debug, Deserialize)]
 struct ZonesFile {
     zones: Vec<Zone>,
-}
-
-fn load_zones() -> Vec<Zone> {
-    let toml_str = fs::read_to_string("data/zones.toml")
-        .expect("failed to read zones.toml");
-
-    let zones_file: ZonesFile = toml::from_str(&toml_str)
-        .expect("failed to parse toml");
-
-zones_file.zones
 }
 
 #[derive(Debug, Clone)]
@@ -156,18 +175,6 @@ impl Zone {
     }
 }
 
-// #[derive(Template)]
-// #[template(path = "login.html")]
-// struct LoginTemplate<'a>{
-//     email: &'a str,
-// }
-
-// async fn login() -> impl axum::response::IntoResponse {
-//     LoginTemplate {
-//         email : "avon@avon.avon"
-//     }
-// }
-
 #[derive(Debug)]
 struct AppState {
     guesses: Mutex<Vec<Vec<CompareResult>>>,
@@ -189,7 +196,6 @@ async fn main() {
         .route("/", get(homepage))
         .route("/choose_zone", post(choose_zone))
         .with_state(state.clone())
-        // .route("/login", get(login))
         .merge(static_files);
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,196 +1,24 @@
-use std::{
-    fs,
-    fmt,
-    sync::Arc,
-    sync::Mutex
-};
-
-use axum::{
-    extract::{Form, State},
-    routing::get,
-    Router
-};
-
-use tower_http::services::ServeDir;
-use askama_axum::Template;
 use std::net::SocketAddr;
-use axum::routing::post;
-use serde::Deserialize;
+use std::sync::Arc;
 
-// pages
-#[derive(Template)]
-#[template(path = "homepage.html")]
-struct HomepageTemplate {
-    results_history: Vec<Vec<(String, CompareResult)>>,
-    zones: Vec<Zone>,
-}
+use axum::{routing::{get, post}, Router};
+use tower_http::services::ServeDir;
 
-async fn homepage() -> impl axum::response::IntoResponse {
-    HomepageTemplate {
-        results_history: vec![],
-        zones: load_zones(),
-    }
-}
+mod state;
+mod models;
+mod compare;
+mod handlers;
+mod templates;
+mod utils;
 
-#[derive(Deserialize)]
-struct ZoneChoice {
-    zone_name: String,
-}
-
-// load zones like a generic tree
-fn load_raw() -> toml::Value {
-    let zones = std::fs::read_to_string("data/zones.toml").unwrap();
-    toml::from_str(&zones).unwrap()
-}
-
-// load zones as a vector of every zones
-fn load_zones() -> Vec<Zone> {
-    let toml_str = fs::read_to_string("data/zones.toml")
-        .expect("failed to read zones.toml");
-
-    let zones_file: ZonesFile = toml::from_str(&toml_str)
-        .expect("failed to parse toml");
-
-    zones_file.zones
-}
-
-fn load_labels_and_zones() -> (Vec<String>, Vec<Zone>) {
-    let raw = load_raw();
-
-    // récupérer l'ordre des labels
-    let labels = raw["labels"]
-        .as_array().unwrap()
-        .iter()
-        .map(|v| v.as_str().unwrap().to_string())
-        .collect::<Vec<_>>();
-
-    let zones_vec = load_zones();
-
-    (labels, zones_vec)
-}
-
-fn label_results(results: Vec<CompareResult>, labels: &Vec<String>) -> Vec<(String, CompareResult)> {
-    labels.iter().cloned().zip(results).collect()
-}
-
-async fn choose_zone(State(state): State<Arc<AppState>>, Form(input): Form<ZoneChoice>) -> impl axum::response::IntoResponse {
-    // target hardcoded for now (need to be chosen every day randomly)
-    let target = Zone { name: "Moss Grotto".to_string(), size: 18, acte: 1, bosses: 4, station: true };
-    
-    // loading every labels and zones from the zones.toml file
-    let (labels, all_zones) = load_labels_and_zones();
-    // getting the zone struct with input zone name
-    let chosen = all_zones.iter()
-        .find(|z| z.name == input.zone_name)
-        .expect("the chosen zone does not exist");
-
-    // actual comparison (core logic)
-    let results = chosen.compare(&target);
-
-    let results_history: Vec<Vec<(String, CompareResult)>> = {
-    let mut guesses = state.guesses.lock().unwrap();
-    guesses.push(results);
-    guesses.iter()
-        .map(|g| label_results(g.clone(), &labels))
-        .collect()
-    };
-
-    HomepageTemplate {
-        results_history,
-        zones: all_zones,
-    }
-}
-
-// core logic
-#[derive(Debug, Deserialize)]
-struct Zone {
-    name: String, // name on the map
-    size: u8, // numbers of rooms (for now)
-    acte: u8, // 1, 2 or 3: is it accessible normally ? (the intended way)
-    bosses: u8, // numbers of bosses
-    station: bool, // is there a station in the zone
-}
-
-#[derive(Debug, Deserialize)]
-struct ZonesFile {
-    zones: Vec<Zone>,
-}
-
-#[derive(Debug, Clone)]
-enum CompareResult {
-    Smaller,
-    Greater,
-    Equal,
-    NotCorrect
-}
-
-impl fmt::Display for CompareResult {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            CompareResult::Smaller => write!(f, "Smaller"),
-            CompareResult::Greater => write!(f, "Greater"),
-            CompareResult::Equal => write!(f, "Equal"),
-            CompareResult::NotCorrect => write!(f, "NotCorrect"),
-        }
-    }
-}
-
-fn compare_values<T: Ord>(a: &T, b: &T) -> CompareResult {
-    if a < b {
-        CompareResult::Smaller
-    } else if a > b {
-        CompareResult::Greater
-    } else {
-        CompareResult::Equal
-    }
-}
-
-fn compare_str(a: &str, b: &str) -> CompareResult {
-    if a == b {
-        CompareResult::Equal
-    } else {
-        CompareResult::NotCorrect
-    }
-}
-
-fn compare_bool(a: &bool, b: &bool) -> CompareResult {
-    if a == b {
-        CompareResult::Equal
-    } else {
-        CompareResult::NotCorrect
-    }
-}
-
-impl Zone {
-    fn compare(&self, other: &Zone) -> Vec<CompareResult> {
-        let mut results = Vec::new();
-        
-        results.push(compare_str(&self.name, &other.name));
-        results.push(compare_values(&self.size, &other.size));
-        results.push(compare_values(&self.acte, &other.acte));
-        results.push(compare_values(&self.bosses, &other.bosses));
-        results.push(compare_bool(&self.station, &other.station));
-        
-        results
-    }
-}
-
-#[derive(Debug)]
-struct AppState {
-    guesses: Mutex<Vec<Vec<CompareResult>>>,
-}
+use crate::state::AppState;
+use crate::handlers::{homepage, choose_zone};
 
 #[tokio::main]
 async fn main() {
-    let state = Arc::new(AppState {
-        guesses: Mutex::new(vec![]),
-    });
-    
-    // router
-    let static_files = axum::Router::new().nest_service(
-        "/static",
-        ServeDir::new("static")
-    );
+    let state = Arc::new(AppState::new());
+
+    let static_files = Router::new().nest_service("/static", ServeDir::new("static"));
 
     let app = Router::new()
         .route("/", get(homepage))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,12 @@
 use std::{
     fs,
-    fmt
+    fmt,
+    sync::Arc,
+    sync::Mutex
 };
 
 use axum::{
-    extract::Form,
+    extract::{Form, State},
     routing::get,
     Router
 };
@@ -19,13 +21,13 @@ use serde::Deserialize;
 #[derive(Template)]
 #[template(path = "homepage.html")]
 struct HomepageTemplate {
-    results_zone: Vec<(&'static str, CompareResult)>,
+    results_history: Vec<Vec<(&'static str, CompareResult)>>,
     zones: Vec<Zone>,
 }
 
 async fn homepage() -> impl axum::response::IntoResponse {
     HomepageTemplate {
-        results_zone: vec![],
+        results_history: vec![],
         zones: load_zones(),
     }
 }
@@ -35,7 +37,11 @@ struct ZoneChoice {
     zone_name: String,
 }
 
-async fn choose_zone(Form(input): Form<ZoneChoice>) -> impl axum::response::IntoResponse {
+fn label_results(results: Vec<CompareResult>, labels: [&'static str; 5]) -> Vec<(&'static str, CompareResult)> {
+    labels.into_iter().zip(results).collect()
+}
+
+async fn choose_zone(State(state): State<Arc<AppState>>, Form(input): Form<ZoneChoice>) -> impl axum::response::IntoResponse {
     // every zones
     let all_zones = load_zones();
     // labels of the results
@@ -49,11 +55,18 @@ async fn choose_zone(Form(input): Form<ZoneChoice>) -> impl axum::response::Into
     let chosen = all_zones.iter().find(|z| z.name == chosen_name).expect("the chosen zone does not exist");
 
     // final comparison between the target and chosen zone creating a CompareResult vec, using it for display
-    let results = chosen.compare(&target);
-    let results_zone: Vec<(&'static str, CompareResult)> = labels.into_iter().zip(results).collect();
+    let results: Vec<CompareResult> = chosen.compare(&target);
+
+    let results_history: Vec<Vec<(&'static str, CompareResult)>> = {
+        let mut guesses = state.guesses.lock().unwrap();
+        guesses.push(results);
+        guesses.iter()
+            .map(|g| label_results(g.clone(), labels))
+            .collect()
+    };
 
     HomepageTemplate {
-        results_zone,
+        results_history,
         zones: all_zones,
     }
 }
@@ -84,6 +97,7 @@ fn load_zones() -> Vec<Zone> {
 zones_file.zones
 }
 
+#[derive(Debug, Clone)]
 enum CompareResult {
     Smaller,
     Greater,
@@ -154,8 +168,17 @@ impl Zone {
 //     }
 // }
 
+#[derive(Debug)]
+struct AppState {
+    guesses: Mutex<Vec<Vec<CompareResult>>>,
+}
+
 #[tokio::main]
 async fn main() {
+    let state = Arc::new(AppState {
+        guesses: Mutex::new(vec![]),
+    });
+    
     // router
     let static_files = axum::Router::new().nest_service(
         "/static",
@@ -165,6 +188,7 @@ async fn main() {
     let app = Router::new()
         .route("/", get(homepage))
         .route("/choose_zone", post(choose_zone))
+        .with_state(state.clone())
         // .route("/login", get(login))
         .merge(static_files);
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,0 +1,15 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct Zone {
+    pub name: String,
+    pub size: u8,
+    pub acte: u8,
+    pub bosses: u8,
+    pub station: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ZonesFile {
+    pub zones: Vec<Zone>,
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,16 @@
+use std::sync::Mutex;
+
+use crate::compare::CompareResult;
+
+#[derive(Debug)]
+pub struct AppState {
+    pub guesses: Mutex<Vec<Vec<CompareResult>>>,
+}
+
+impl AppState {
+    pub fn new() -> Self {
+        AppState {
+            guesses: Mutex::new(vec![]),
+        }
+    }
+}

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,0 +1,10 @@
+use askama_axum::Template;
+
+use crate::{compare::CompareResult, models::Zone};
+
+#[derive(Template)]
+#[template(path = "homepage.html")]
+pub struct HomepageTemplate {
+    pub results_history: Vec<Vec<(String, CompareResult)>>,
+    pub zones: Vec<Zone>,
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,36 @@
+use std::fs;
+
+use crate::{models::{Zone, ZonesFile}, compare::CompareResult};
+
+pub fn load_raw() -> toml::Value {
+    let zones = std::fs::read_to_string("data/zones.toml").unwrap();
+    toml::from_str(&zones).unwrap()
+}
+
+pub fn load_zones() -> Vec<Zone> {
+    let toml_str = fs::read_to_string("data/zones.toml")
+        .expect("failed to read zones.toml");
+
+    let zones_file: ZonesFile = toml::from_str(&toml_str)
+        .expect("failed to parse toml");
+
+    zones_file.zones
+}
+
+pub fn load_labels_and_zones() -> (Vec<String>, Vec<Zone>) {
+    let raw = load_raw();
+
+    let labels = raw["labels"]
+        .as_array().unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect::<Vec<_>>();
+
+    let zones_vec = load_zones();
+
+    (labels, zones_vec)
+}
+
+pub fn label_results(results: Vec<CompareResult>, labels: &Vec<String>) -> Vec<(String, CompareResult)> {
+    labels.iter().cloned().zip(results).collect()
+}

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -1,10 +1,12 @@
 {% extends "base.html" %}
 {% block content %}
-    <ul>
-      {% for (label, results) in results_zone %}
-        <li>{{ label }} : {{ results }}</li>
-      {% endfor %}
-    </ul>
+    {% for guess in results_history %}
+      <ul>
+        {% for (label, result) in guess %}
+          <li>{{ label }} : {{ result }}</li>
+        {% endfor %}
+      </ul>
+    {% endfor %}
 
     <form action="/choose_zone" method="post">
         <select name="zone_name">


### PR DESCRIPTION
restructurate file arborescence by splitting main into 7 files:

- compare (core logic functions, the game is about comparing your guess and a secret answer)
- handlers (everything that handle frontend request and send backend pages with updated calculated data)
- main (starting the server and declaring an AppState for global persistend variable, router and connecting static files)
- models (data models used in the app)
- state (variables in AppState declaration, would be more useful later as more global persistend variable would be needed)
- templates (declaring how pages are supposed to be from backend perspective via templates, the variables)
- utils (getting the data from files in the server, it's like a db model but without a db since there no need for now)